### PR TITLE
Add meta data to onMetaData on stream connection

### DIFF
--- a/rtmp/src/main/java/com/github/faucamp/simplertmp/DefaultRtmpPublisher.java
+++ b/rtmp/src/main/java/com/github/faucamp/simplertmp/DefaultRtmpPublisher.java
@@ -55,4 +55,9 @@ public class DefaultRtmpPublisher implements RtmpPublisher {
   public void setLogs(boolean enable) {
     rtmpConnection.setLogs(enable);
   }
+
+  @Override
+  public void addMetaData(Object kvp) {
+    rtmpConnection.addMetaData(kvp);
+  }
 }

--- a/rtmp/src/main/java/com/github/faucamp/simplertmp/RtmpPublisher.java
+++ b/rtmp/src/main/java/com/github/faucamp/simplertmp/RtmpPublisher.java
@@ -61,4 +61,6 @@ public interface RtmpPublisher {
   void setAuthorization(String user, String password);
 
   void setLogs(boolean enable);
+
+  void addMetaData(Object kvp);
 }

--- a/rtmp/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
+++ b/rtmp/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
@@ -32,6 +32,9 @@ import java.util.regex.Pattern;
 import net.ossrs.rtmp.BitrateManager;
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 import net.ossrs.rtmp.CreateSSLSocket;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Main RTMP connection implementation class
@@ -363,6 +366,24 @@ public class RtmpConnection implements RtmpPublisher {
     ecmaArray.setProperty("audiodatarate", 0);
     ecmaArray.setProperty("stereo", true);
     ecmaArray.setProperty("filesize", 0);
+
+    if (addlMetaData instanceof JSONObject) {
+      try {
+        JSONObject jsonMetaData = (JSONObject) addlMetaData;
+        JSONArray keys = jsonMetaData.names();
+
+        if (keys != null) {
+          for (int i = 0; i < keys.length(); i++) {
+            String key = keys.getString(i);
+            String value = jsonMetaData.getString(key);
+            ecmaArray.setProperty(key, value);
+          }
+        }
+      } catch (JSONException | NullPointerException e) {
+        Log.getStackTraceString(e);
+      }
+    }
+
     metadata.addData(ecmaArray);
     sendRtmpPacket(metadata);
   }

--- a/rtmp/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
+++ b/rtmp/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
@@ -79,6 +79,7 @@ public class RtmpConnection implements RtmpPublisher {
   private String netConnectionDescription;
   private final BitrateManager bitrateManager;
   private boolean isEnableLogs = true;
+  private Object addlMetaData;
 
   public RtmpConnection(ConnectCheckerRtmp connectCheckerRtmp) {
     this.connectCheckerRtmp = connectCheckerRtmp;
@@ -738,5 +739,9 @@ public class RtmpConnection implements RtmpPublisher {
 
   public void setLogs(boolean enable) {
     isEnableLogs = enable;
+  }
+
+  public void addMetaData(Object kvp) {
+    addlMetaData = kvp;
   }
 }

--- a/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
@@ -1066,4 +1066,8 @@ public class SrsFlvMuxer {
   public void setLogs(boolean enable) {
     publisher.setLogs(enable);
   }
+
+  public void addMetaData(Object kvp) {
+    publisher.addMetaData(kvp);
+  }
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
@@ -911,4 +911,6 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
   }
 
   public abstract void setLogs(boolean enable);
+
+  public abstract void addMetaData(Object kvp);
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
@@ -199,5 +199,10 @@ public class RtmpCamera2 extends Camera2Base {
   public void setLogs(boolean enable) {
     srsFlvMuxer.setLogs(enable);
   }
+
+  @Override
+  public void addMetaData(Object kvp) {
+    srsFlvMuxer.addMetaData(kvp);
+  }
 }
 

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
@@ -194,5 +194,10 @@ public class RtspCamera2 extends Camera2Base {
   public void setLogs(boolean enable) {
     rtspClient.setLogs(enable);
   }
+
+  @Override
+  public void addMetaData(Object kvp) {
+
+  }
 }
 

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/util/BitrateAdapter.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/util/BitrateAdapter.java
@@ -3,7 +3,6 @@ package com.pedro.rtplibrary.util;
 /**
  * Created by pedro on 11/07/19.
  */
-// BitrateAdapter
 public class BitrateAdapter {
 
   public interface Listener {


### PR DESCRIPTION
Allows the user to add additional metadata to the livestream onMetaData() rtmp packet

Livestream RemoteCamera Example:
```
JSONObject value = new JSONObject();
try {
    value.put("lat", "34.343434");
    value.put("lng", "-77.2323491");
    rtmpCamera2.addMetaData(value);
} catch (JSONException e) {
    e.printStackTrace();
}

Log.d(TAG, "STARTING STREAM");
String currentUrl = "rtmp://52.0.134.218:1935/live/AmethystPhone";
Log.d(TAG, "Connect at -> " + currentUrl);

rtmpCamera2.startStream(currentUrl);
```

Resulting RTMP onMetaData packet frame in wireshark:
```
RTMP Body
    String 'onMetaData'
        AMF0 type: String (0x02)
        String length: 10
        String: onMetaData
    Object (12 items)
        AMF0 type: Object (0x03)
        Property 'duration' Number 0
        Property 'width' Number 360
        Property 'height' Number 640
        Property 'videocodecid' Number 7
        Property 'framerate' Number 30
        Property 'videodatarate' Number 0
        Property 'audiocodecid' Number 10
        Property 'audiosamplerate' Number 44100
        Property 'audiosamplesize' Number 16
        Property 'audiodatarate' Number 0
        Property 'stereo' Boolean true
        Property 'filesize' Number 0
        End Of Object Marker
```
